### PR TITLE
Import super from objc to fix AttributeError

### DIFF
--- a/pyttsx4/drivers/nsss.py
+++ b/pyttsx4/drivers/nsss.py
@@ -2,6 +2,7 @@
 from Foundation import *
 from AppKit import NSSpeechSynthesizer
 from PyObjCTools import AppHelper
+from objc import super
 from ..voice import Voice
 
 


### PR DESCRIPTION
Added an import to the `objc` version of `super` to fix an `AttributeError` which happens with `pyobjc` 9.1.1.

See here for details as to why it's needed: https://github.com/ronaldoussoren/pyobjc/issues/549

This can be worked around for now by using `pyobjc` 9.0.1.